### PR TITLE
privateFields can be optional

### DIFF
--- a/src/main/scala/com/gu/identity/play/IdUser.scala
+++ b/src/main/scala/com/gu/identity/play/IdUser.scala
@@ -4,9 +4,9 @@ import play.api.libs.json.Json
 
 
 case class IdUser(id: String,
-                  primaryEmailAddress: String,
+                  primaryEmailAddress: Option[String],
                   publicFields: PublicFields,
-                  privateFields: PrivateFields,
+                  privateFields: Option[PrivateFields],
                   statusFields: Option[StatusFields])
 
 

--- a/src/main/scala/com/gu/identity/play/IdUser.scala
+++ b/src/main/scala/com/gu/identity/play/IdUser.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.Json
 
 
 case class IdUser(id: String,
-                  primaryEmailAddress: Option[String],
+                  primaryEmailAddress: String,
                   publicFields: PublicFields,
                   privateFields: Option[PrivateFields],
                   statusFields: Option[StatusFields])


### PR DESCRIPTION
For the calls Subscriptions need to make primaryEmaillAddress and privateFields can be optional.

@davidrapson If Membership upgrades to this library you'll have to update a few places. Sorry.
