### PR TITLE
Fix the silently-breaking Sonatype release process

### DIFF
--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,3 +1,5 @@
+sonatypeProfileName := "com.gu"
+
 pomExtra := (
   <url>https://github.com/guardian/identity-auth</url>
     <developers>


### PR DESCRIPTION
We need to set the `sonatypeProfileName` key because- for this project - the artifact group name is `com.gu.identity`, but the Sonatype account we use is just `com.gu`.

https://github.com/xerial/sbt-sonatype/blob/1961d6988/src/main/scala/xerial/sbt/Sonatype.scala#L53

cc @jennysivapalan - I think this is why `sbt release` was failing for this project.
