### PR TITLE
Add a facility to create cookies from a guest conversion response

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies ++= Seq(
   nscalaTime,
   identityCookie,
   identityTestUsers,
-  scalaTestPlus % Test
+  scalaTestPlus % Test,
+  scalactic % Test
 )
 
 lazy val root = project in file(".")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,5 +7,6 @@ object Dependencies {
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val nscalaTime = "com.github.nscala-time" %% "nscala-time" % "2.0.0"
   val scalaTestPlus = "org.scalatestplus" %% "play" % "1.4.0-M3"
+  val scalactic = "org.scalactic" %% "scalactic" % "2.2.4"
 
 }

--- a/src/main/scala/com/gu/identity/play/CookieBuilder.scala
+++ b/src/main/scala/com/gu/identity/play/CookieBuilder.scala
@@ -1,0 +1,33 @@
+package com.gu.identity.play
+import org.joda.time.{DateTime, Duration}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+import play.api.mvc.Cookie
+
+import scala.util.Try
+
+object CookieBuilder {
+  def fromGuestConversion(json: JsValue, domain: Option[String] = None): Option[Seq[Cookie]] = {
+    implicit val cookieRead: Reads[Cookie] = (
+      (JsPath \ "key").read[String] and
+        (JsPath \ "value").read[String]
+      )(Cookie.apply(_, _))
+
+    for {
+      expirationString <- (json \ "cookies" \ "expiresAt").asOpt[String]
+      expiration <- Try { new DateTime(expirationString) }.toOption
+      maxAge = new Duration(DateTime.now, expiration).getStandardSeconds.toInt
+      cookies <- (json \ "cookies" \ "values").asOpt[Seq[Cookie]]
+      guuCookie <- cookies.find(_.name == "GU_U")
+      scguuCookie <- cookies.find(_.name == "SC_GU_U")
+      scgulaCookie <- cookies.find(_.name == "SC_GU_LA")
+    } yield {
+      Seq(
+        guuCookie.copy(maxAge = Some(maxAge), secure = false, httpOnly = false, domain = domain),
+        scguuCookie.copy(maxAge = Some(maxAge), secure = true, httpOnly = true, domain = domain),
+        scgulaCookie.copy(secure = true, httpOnly = true, domain = domain)
+      )
+    }
+  }
+}

--- a/src/main/scala/com/gu/identity/play/CookieBuilder.scala
+++ b/src/main/scala/com/gu/identity/play/CookieBuilder.scala
@@ -9,25 +9,21 @@ import scala.util.Try
 
 object CookieBuilder {
   def fromGuestConversion(json: JsValue, domain: Option[String] = None): Option[Seq[Cookie]] = {
-    implicit val cookieRead: Reads[Cookie] = (
+    def cookieRead(maxAge: Int): Reads[Cookie] = (
       (JsPath \ "key").read[String] and
-        (JsPath \ "value").read[String]
-      )(Cookie.apply(_, _))
+        (JsPath \ "value").read[String] and
+        (JsPath \ "sessionCookie").readNullable[Boolean]
+      ) { (name, value, sessionCookie) =>
+        val secure = name.startsWith("SC_")
+        val maxAgeOpt = if (sessionCookie.contains(true)) None else Some(maxAge)
+        Cookie(name, value, maxAge = maxAgeOpt, secure = secure, httpOnly = secure, domain = domain)
+      }
 
     for {
       expirationString <- (json \ "cookies" \ "expiresAt").asOpt[String]
       expiration <- Try { new DateTime(expirationString) }.toOption
       maxAge = new Duration(DateTime.now, expiration).getStandardSeconds.toInt
-      cookies <- (json \ "cookies" \ "values").asOpt[Seq[Cookie]]
-      guuCookie <- cookies.find(_.name == "GU_U")
-      scguuCookie <- cookies.find(_.name == "SC_GU_U")
-      scgulaCookie <- cookies.find(_.name == "SC_GU_LA")
-    } yield {
-      Seq(
-        guuCookie.copy(maxAge = Some(maxAge), secure = false, httpOnly = false, domain = domain),
-        scguuCookie.copy(maxAge = Some(maxAge), secure = true, httpOnly = true, domain = domain),
-        scgulaCookie.copy(secure = true, httpOnly = true, domain = domain)
-      )
-    }
+      cookies <- (json \ "cookies" \ "values").asOpt(Reads.seq[Cookie](cookieRead(maxAge)))
+    } yield cookies
   }
 }

--- a/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
+++ b/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
@@ -49,21 +49,21 @@ class CookieBuilderTest extends FreeSpec {
       assert(guuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
       assert(!guuCookie.secure)
       assert(!guuCookie.httpOnly)
-      assert(guuCookie === domain)
+      assert(guuCookie.domain === domain)
 
       assert(scguuCookie.name === "SC_GU_U")
       assert(scguuCookie.value === "sc_gu_u_value")
       assert(scguuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
       assert(scguuCookie.secure)
       assert(scguuCookie.httpOnly)
-      assert(scguuCookie === domain)
+      assert(scguuCookie.domain === domain)
 
       assert(scgulaCookie.name === "SC_GU_LA")
       assert(scgulaCookie.value === "sc_gu_la_value")
       assert(scgulaCookie.maxAge === None)
       assert(scgulaCookie.secure)
       assert(scgulaCookie.httpOnly)
-      assert(scgulaCookie === domain)
+      assert(scgulaCookie.domain === domain)
     }
   }
 }

--- a/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
+++ b/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
@@ -42,7 +42,7 @@ class CookieBuilderTest extends FreeSpec {
 
       val domain = Some("domain")
       val idCookies = CookieBuilder.fromGuestConversion(json, domain)
-      val Some(Seq(guuCookie, scguuCookie, scgulaCookie)) = idCookies
+      val Some(Seq(guuCookie, scgulaCookie, scguuCookie)) = idCookies
 
       assert(guuCookie.name === "GU_U")
       assert(guuCookie.value === "gu_u_value")
@@ -51,19 +51,19 @@ class CookieBuilderTest extends FreeSpec {
       assert(!guuCookie.httpOnly)
       assert(guuCookie.domain === domain)
 
-      assert(scguuCookie.name === "SC_GU_U")
-      assert(scguuCookie.value === "sc_gu_u_value")
-      assert(scguuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
-      assert(scguuCookie.secure)
-      assert(scguuCookie.httpOnly)
-      assert(scguuCookie.domain === domain)
-
       assert(scgulaCookie.name === "SC_GU_LA")
       assert(scgulaCookie.value === "sc_gu_la_value")
       assert(scgulaCookie.maxAge === None)
       assert(scgulaCookie.secure)
       assert(scgulaCookie.httpOnly)
       assert(scgulaCookie.domain === domain)
+
+      assert(scguuCookie.name === "SC_GU_U")
+      assert(scguuCookie.value === "sc_gu_u_value")
+      assert(scguuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
+      assert(scguuCookie.secure)
+      assert(scguuCookie.httpOnly)
+      assert(scguuCookie.domain === domain)
     }
   }
 }

--- a/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
+++ b/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
@@ -1,0 +1,69 @@
+package com.gu.identity.play
+
+import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.{DateTime, Duration}
+import org.scalactic.Tolerance._
+import org.scalatest.FreeSpec
+import play.api.libs.json.Json
+
+class CookieBuilderTest extends FreeSpec {
+  "After registering a guest user" - {
+    "The response we get can be read as identity cookies" in {
+      val now = DateTime.now
+      val inThreeMonths = now.plus(Duration.standardDays(90L))
+
+      // 2015-12-28T15:22:01+00:00
+      val inThreeMonthsStr =ISODateTimeFormat.dateHourMinuteSecond.print(inThreeMonths) + "+00:00"
+
+      val json =
+        Json.parse(s"""
+                      |{
+                      |  "status": "ok",
+                      |  "cookies": {
+                      |    "values": [
+                      |      {
+                      |        "key": "GU_U",
+                      |        "value": "gu_u_value"
+                      |      },
+                      |      {
+                      |        "key": "SC_GU_LA",
+                      |        "value": "sc_gu_la_value",
+                      |        "sessionCookie": true
+                      |      },
+                      |      {
+                      |        "key": "SC_GU_U",
+                      |        "value": "sc_gu_u_value"
+                      |      }
+                      |    ],
+                      |    "expiresAt": "$inThreeMonthsStr"
+                      |  }
+                      |}
+        """.stripMargin)
+
+      val domain = Some("domain")
+      val idCookies = CookieBuilder.fromGuestConversion(json, domain)
+      val Some(Seq(guuCookie, scguuCookie, scgulaCookie)) = idCookies
+
+      assert(guuCookie.name === "GU_U")
+      assert(guuCookie.value === "gu_u_value")
+      assert(guuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
+      assert(!guuCookie.secure)
+      assert(!guuCookie.httpOnly)
+      assert(guuCookie === domain)
+
+      assert(scguuCookie.name === "SC_GU_U")
+      assert(scguuCookie.value === "sc_gu_u_value")
+      assert(scguuCookie.maxAge.get === (90 * 24 * 60 * 60) +- 5)
+      assert(scguuCookie.secure)
+      assert(scguuCookie.httpOnly)
+      assert(scguuCookie === domain)
+
+      assert(scgulaCookie.name === "SC_GU_LA")
+      assert(scgulaCookie.value === "sc_gu_la_value")
+      assert(scgulaCookie.maxAge === None)
+      assert(scgulaCookie.secure)
+      assert(scgulaCookie.httpOnly)
+      assert(scgulaCookie === domain)
+    }
+  }
+}


### PR DESCRIPTION
Creates GU cookies from the response that we get from registering a guest user.

See https://github.com/guardian/subscriptions-frontend/pull/236
