### PR TITLE
Support authentication through Identity Access Tokens as well as cookies

### DIFF
--- a/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
@@ -1,6 +1,76 @@
 package com.gu.identity.play
 
-/**
- * @param authCookie - the "SC_GU_U" cookie the user authenticated with
- */
-case class AuthenticatedIdUser(authCookie: String, user: IdMinimalUser)
+import com.github.nscala_time.time.Imports._
+import com.gu.identity.cookie.{IdentityCookieDecoder, IdentityKeys}
+import com.gu.identity.model.{CryptoAccessToken, LiftJsonConfig, User}
+import com.gu.identity.play.AuthenticatedIdUser.Provider
+import com.gu.identity.signing.{CollectionSigner, DsaService, StringSigner}
+import org.joda.time.DateTime
+import play.api.mvc.RequestHeader
+
+case class AuthenticatedIdUser(credentials: AccessCredentials, user: IdMinimalUser)
+
+object AuthenticatedIdUser {
+  implicit def authenticatedIdUserToMinimalUser(aid: AuthenticatedIdUser) = aid.user
+
+  type Provider = RequestHeader => Option[AuthenticatedIdUser]
+
+  def provider(providers: Provider*) = {
+    r : RequestHeader => providers.flatMap(_(r)).headOption
+  }
+}
+
+sealed trait AccessCredentials
+
+object AccessCredentials {
+  case class Cookies(scGuU: String, guU: String) extends AccessCredentials {
+    val forwardingHeader = "X-GU-ID-FOWARDED-SC-GU-U" -> scGuU
+  }
+
+  object Cookies {
+    def authProvider(identityKeys: IdentityKeys): Provider = {
+      val cookieDecoder = new IdentityCookieDecoder(identityKeys)
+
+      request => for {
+        scGuU <- request.cookies.get("SC_GU_U")
+        guU <- request.cookies.get("GU_U")
+        minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
+        guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
+        user = guUCookieData.user if user.id == minimalSecureUser.id
+      } yield AuthenticatedIdUser(
+        AccessCredentials.Cookies(scGuU.value, guU.value),
+        IdMinimalUser.from(user)
+      )
+    }
+  }
+
+  case class Token(tokenText: String) extends AccessCredentials
+
+  object Token {
+    /** @param targetClientId Not confidential, eg "members-data-api" https://github.com/guardian/identity-token-auth-sample/blob/e640832d/main.scala#L28
+      */
+    def authProvider(identityKeys: IdentityKeys, targetClientId: String): Provider = {
+      val collectionSigner = new CollectionSigner(new StringSigner(new DsaService(identityKeys.publicDsaKey, null)), LiftJsonConfig.formats)
+
+      // Adapted from https://github.com/guardian/identity/blob/8663b03/identity-api-client-lib/src/main/java/com/gu/identity/client/IdentityApiClient.java#L321-L334
+      def extractUserDataFromToken(tokenString: String) = {
+        val cryptoAccessToken = collectionSigner.getValueForSignedStringJava(tokenString, classOf[CryptoAccessToken])
+
+        if (cryptoAccessToken.expiryTime < DateTime.now) {
+          Left(s"Token: $tokenString has expired")
+        } else if (cryptoAccessToken.targetClient != targetClientId) {
+          Left(s"Token: $tokenString was not targeted for the client '$targetClientId'")
+        } else Right(cryptoAccessToken.getUser)
+      }
+
+      request => for {
+        tokenText <- request.headers.get("GU-IdentityToken")
+        user <- extractUserDataFromToken(tokenText).right.toOption
+      } yield AuthenticatedIdUser(
+        AccessCredentials.Token(tokenText),
+        IdMinimalUser.from(user)
+      )
+    }
+  }
+}
+

--- a/src/main/scala/com/gu/identity/play/AuthenticationService.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticationService.scala
@@ -1,24 +1,17 @@
 package com.gu.identity.play
 
-import com.gu.identity.cookie.{IdentityCookieDecoder, IdentityKeys}
+import com.gu.identity.cookie.IdentityKeys
 import play.api.mvc.{Request, RequestHeader}
 
 trait AuthenticationService {
 
   val identityKeys: IdentityKeys
 
-  lazy val cookieDecoder = new IdentityCookieDecoder(identityKeys)
+  val authenticatedIdUserProvider: AuthenticatedIdUser.Provider =
+    AccessCredentials.Cookies.authProvider(identityKeys)
 
-  def authenticatedUserFor[A](request: RequestHeader): Option[AuthenticatedIdUser] = for {
-    scGuU <- request.cookies.get("SC_GU_U")
-    guU <- request.cookies.get("GU_U")
-    minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
-    guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
-    user = guUCookieData.user if user.id == minimalSecureUser.id
-  } yield AuthenticatedIdUser(
-    scGuU.value,
-    IdMinimalUser(user.id, user.publicFields.displayName)
-  )
+  def authenticatedUserFor[A](request: RequestHeader) = authenticatedIdUserProvider(request)
 
   def requestPresentsAuthenticationCredentials(request: Request[_]) = authenticatedUserFor(request).isDefined
+
 }

--- a/src/main/scala/com/gu/identity/play/IdMinimalUser.scala
+++ b/src/main/scala/com/gu/identity/play/IdMinimalUser.scala
@@ -1,3 +1,9 @@
 package com.gu.identity.play
 
+import com.gu.identity.model.User
+
 case class IdMinimalUser(id: String, displayName: Option[String])
+
+object IdMinimalUser {
+  def from(user: User) = IdMinimalUser(user.id, user.publicFields.displayName)
+}


### PR DESCRIPTION
The Guardian mobile apps authenticate through Identity Access Tokens rather Cookies (ie the SC_GU_U, etc cookies), and so we want to support the mobile clients on `members-data-api.theguardian.com`.

This change introduces an `AccessCredentials` object which can be either `Cookies` or `Token`, and supports the requirements of the three current clients of `identity-play-auth`:
- https://github.com/guardian/membership-attribute-service/pull/51
- https://github.com/guardian/membership-frontend/pull/856
- https://github.com/guardian/subscriptions-frontend/pull/271

https://trello.com/c/d7jD8CUW/120-members-data-api-enable-access-by-mobile-access-tokens

See also https://github.com/guardian/identity-token-auth-sample

cc @tomverran @ostapneko @markjamesbutler 
