### PR TITLE
Fix test that failed on daylight-savings-change

### DIFF
--- a/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
+++ b/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
@@ -1,7 +1,10 @@
 package com.gu.identity.play
 
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, Duration}
+
+import java.time.ZoneOffset.UTC
+import java.time._
+import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
 import org.scalactic.Tolerance._
 import org.scalatest.FreeSpec
 import play.api.libs.json.{JsSuccess, Json}
@@ -9,11 +12,10 @@ import play.api.libs.json.{JsSuccess, Json}
 class CookieBuilderTest extends FreeSpec {
   "After registering a guest user" - {
     "The response we get can be read as identity cookies" in {
-      val now = DateTime.now
-      val inThreeMonths = now.plus(Duration.standardDays(90L))
+      val inThreeMonths = ZonedDateTime.now(UTC).plus(Duration.ofDays(90L))
 
       // 2015-12-28T15:22:01+00:00
-      val inThreeMonthsStr =ISODateTimeFormat.dateHourMinuteSecond.print(inThreeMonths) + "+00:00"
+      val inThreeMonthsStr = ISO_OFFSET_DATE_TIME.format(inThreeMonths)
 
       val json =
         Json.parse(s"""


### PR DESCRIPTION
This test would fail if there was going to be a daylight-savings-change in the next 90 days - this is because the generated datetime string was in a system-default timezone, but the string was always manually appended with "+00:00".

BTW, I've started using Java 8 time in preference to Joda where I can easily do so:

"If you are writing code in Java SE 8, its time to migrate to java.time"
...Stephen Colebourne, author of Joda-Time

http://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html

cc @ostapneko
