### PR TITLE
Implement SC_GU_U cookie parsing to avoid Sentry noise

### DIFF
--- a/src/test/scala/com/gu/identity/play/AccessCredentialsSpec.scala
+++ b/src/test/scala/com/gu/identity/play/AccessCredentialsSpec.scala
@@ -1,0 +1,72 @@
+package com.gu.identity.play
+
+import java.time.ZoneOffset.UTC
+import java.time.{Clock, Instant}
+
+import com.gu.identity.cookie.{ProductionKeys, SCUCookieData}
+import com.gu.identity.play.AccessCredentials.Cookies
+import com.gu.identity.play.AccessCredentials.Cookies.parseScGuU
+import org.scalatestplus.play._
+import play.api.test.FakeRequest
+
+import scala.util.Try
+
+class AccessCredentialsSpec extends PlaySpec {
+
+  "parsing Identity cookies" must {
+    def requestWith(accessCredentials: AccessCredentials.Cookies) = FakeRequest().withCookies(accessCredentials.cookies :_*)
+
+    def authProviderWithClockSetTo(instant: Instant) =
+      AccessCredentials.Cookies.authProvider(new ProductionKeys)(Clock.fixed(instant, UTC))
+
+    val validCookies = AccessCredentials.Cookies(
+      guU = "WyIxNTc0NzA5NCIsIiIsImlwYXRlc3QiLCIyIiwxNDU5ODU3MTA2MTc4LDAsMTQ1MjA4MTEwNTAwMCxmYWxzZV0.MCwCFEAUh7K0AuXPCZUjZX7I1KPApDazAhQ38PzDzsHaXQWTSpX51dylUhJcmw",
+      scGuU = "WyIxNTc0NzA5NCIsMTQ1OTg1NzEwNjE3OF0.MC0CFFrjLlGPWJjIFWZskQljWSToGLkSAhUAtaF7F2IAbh4YBeIENLQOlm4FUB8"
+    )
+
+    val cookiesExpirationInstant = Instant.parse("2016-04-05T11:51:46.178Z")
+
+    val instantBeforeExpiration = cookiesExpirationInstant.minusSeconds(1L)
+
+    "extract an authenticated user from an HTTP request" in {
+      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+
+      val authenticatedIdUserOpt = authProvider(requestWith(validCookies))
+
+      val authenticatedIdUser = authenticatedIdUserOpt.value
+      authenticatedIdUser.user.id mustBe "15747094"
+      authenticatedIdUser.user.displayName mustBe Some("ipatest")
+      authenticatedIdUser.credentials mustBe validCookies
+    }
+
+    "report an HTTP request as unauthenticated when the current time is beyond the expiration date" in {
+      val authProvider = authProviderWithClockSetTo(cookiesExpirationInstant.plusSeconds(1L))
+
+      val authenticatedIdUserOpt = authProvider(requestWith(validCookies))
+
+      authenticatedIdUserOpt mustBe None
+    }
+
+    "report an HTTP request as unauthenticated when signature is bad" in {
+      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+
+      val cookiesWithInvalidSignature = validCookies.copy(scGuU = validCookies.scGuU.dropRight(1))
+
+      val authenticatedIdUserOpt = authProvider(requestWith(cookiesWithInvalidSignature))
+
+      authenticatedIdUserOpt mustBe None
+    }
+
+    "report an HTTP request as unauthenticated when cookie is validly signed but has invalid content (from somewhere else!)" in {
+      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+
+      val authenticatedIdUserOpt = authProvider(requestWith(validCookies.copy(scGuU = validCookies.guU)))
+
+      authenticatedIdUserOpt mustBe None
+    }
+
+    "parse Identity details out of SC_GU_U cookie json" in {
+      parseScGuU("""["15747094",1459857106178]""") mustBe Some(SCUCookieData("15747094",1459857106178L))
+    }
+  }
+}

--- a/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
+++ b/src/test/scala/com/gu/identity/play/CookieBuilderTest.scala
@@ -1,7 +1,10 @@
 package com.gu.identity.play
 
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, Duration}
+
+import java.time.ZoneOffset.UTC
+import java.time._
+import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
 import org.scalactic.Tolerance._
 import org.scalatest.FreeSpec
 import play.api.libs.json.{JsSuccess, Json}
@@ -9,11 +12,10 @@ import play.api.libs.json.{JsSuccess, Json}
 class CookieBuilderTest extends FreeSpec {
   "After registering a guest user" - {
     "The response we get can be read as identity cookies" in {
-      val now = DateTime.now
-      val inThreeMonths = now.plus(Duration.standardDays(90L))
+      val inThreeMonths = ZonedDateTime.now(UTC).plus(Duration.ofDays(90L))
 
       // 2015-12-28T15:22:01+00:00
-      val inThreeMonthsStr =ISODateTimeFormat.dateHourMinuteSecond.print(inThreeMonths) + "+00:00"
+      val inThreeMonthsStr = ISO_OFFSET_DATE_TIME.format(inThreeMonths)
 
       val json =
         Json.parse(s"""


### PR DESCRIPTION
The latest release of `identity-cookies` for Scala 2.11 is 3.46:

http://guardian.github.io/maven/repo-releases/com/gu/identity/identity-cookie_2.11/

...and unfortunately it logs cookie expiration at ERROR level:

https://app.getsentry.com/the-guardian/members-data-api/issues/94774352/

I tried to release a newer version of `identity-cookies`, as the logging problem has already been fixed - but I couldn't get a working Scala 2.11 release build going :(

guardian/identity@ef80795
guardian/identity#504

So, in the end, I've re-implemented the offending code.

cc @ostapneko 
