### PR TITLE
Take first IP from X-Forwarded-For header

### DIFF
--- a/src/main/scala/com/gu/identity/play/ProxiedIP.scala
+++ b/src/main/scala/com/gu/identity/play/ProxiedIP.scala
@@ -1,0 +1,17 @@
+package com.gu.identity.play
+
+import java.net.InetAddress
+
+import com.google.common.net.InetAddresses
+import play.api.http.HeaderNames._
+import play.api.mvc.RequestHeader
+
+import scala.util.Try
+
+object ProxiedIP {
+  def getIP(request: RequestHeader): Option[InetAddress] = for {
+    xFor <- request.headers.get(X_FORWARDED_FOR)
+    ipString <- xFor.split(",").headOption if ipString.nonEmpty
+    ip <- Try(InetAddresses.forString(ipString)).toOption
+  } yield ip
+}

--- a/src/test/scala/com/gu/identity/play/ProxiedIPTest.scala
+++ b/src/test/scala/com/gu/identity/play/ProxiedIPTest.scala
@@ -1,0 +1,23 @@
+package com.gu.identity.play
+
+import com.google.common.net.InetAddresses
+import org.scalatest.{Matchers, FlatSpec}
+
+import play.api.test.FakeRequest
+
+class ProxiedIPTest extends FlatSpec with Matchers {
+  "ProxiedIP" should "extract the first ip" in {
+    ProxiedIP.getIP(FakeRequest().withHeaders("X-Forwarded-For" -> "77.91.250.233, 77.91.250.233, 185.31.18.24")) should be(Some(InetAddresses.forString("77.91.250.233")))
+  }
+
+  "ProxiedIP" should "not crash if XForwardedFor is not present" in {
+    assert(ProxiedIP.getIP(FakeRequest()).isEmpty)
+  }
+  "ProxiedIP" should "return none for empty XForwardedFor" in {
+    assert(ProxiedIP.getIP(FakeRequest().withHeaders("X-Forwarded-For" -> "")).isEmpty)
+  }
+  "ProxiedIP" should "not crash if XForwardedFor is not an ip address" in {
+    assert(ProxiedIP.getIP(FakeRequest().withHeaders("X-Forwarded-For" -> "notanip")).isEmpty)
+  }
+
+}


### PR DESCRIPTION
Because Plays remoteIP address uses whitelists, it was returning fastly ip’s. To avoid the maintenance of updating this whitelist, we’ll be trusting the first entry in the header. This is recorded for auditing for tax purposes and is not security related.

See trello:
https://trello.com/c/I94f2NAl/284-custom-data-fields-for-2-0-subscriber-ip-address

And: 

https://github.com/guardian/membership-common/pull/152
