### PR TITLE
Support Mobile apps authenticating using a SC_GU_U + access-token combo

### DIFF
--- a/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
@@ -6,6 +6,7 @@ import java.time.Clock.systemUTC
 import com.github.nscala_time.time.Imports._
 import com.gu.identity.cookie.{IdentityCookieDecoder, IdentityKeys, SCUCookieData}
 import com.gu.identity.model.{User, CryptoAccessToken, LiftJsonConfig}
+import com.gu.identity.play.AccessCredentials.Cookies.SC_GU_U
 import com.gu.identity.play.AuthenticatedIdUser.Provider
 import com.gu.identity.signing.{CollectionSigner, DsaService, StringSigner}
 import org.joda.time.DateTime
@@ -23,28 +24,45 @@ object AuthenticatedIdUser {
   type Provider = RequestHeader => Option[AuthenticatedIdUser]
 
   def provider(providers: Provider*) = {
-    r : RequestHeader => providers.flatMap(_(r)).headOption
+    r : RequestHeader =>
+      val users = providers.flatMap(_ (r)) // may be differing users!
+
+      for {
+        principal <- users.headOption if users.forall(_.id == principal.id) // reject ambiguity of different users!
+      } yield {
+        val displayNameOpt = users.flatMap(_.displayName).headOption
+        principal.copy(user = principal.user.copy(displayName = displayNameOpt))
+      }
   }
 }
 
 sealed trait AccessCredentials
 
 object AccessCredentials {
-  case class Cookies(scGuU: String, guU: String) extends AccessCredentials {
+  case class Cookies(scGuU: String) extends AccessCredentials {
     val forwardingHeader = "X-GU-ID-FOWARDED-SC-GU-U" -> scGuU
 
     val cookies = Seq(
-      Cookie("SC_GU_U", scGuU),
-      Cookie("GU_U", guU)
+      Cookie(SC_GU_U, scGuU)
     )
   }
 
   object Cookies {
+    val GU_U = "GU_U"
+    val SC_GU_U = "SC_GU_U"
+
     val logger = Logger(getClass)
 
     def authProvider(identityKeys: IdentityKeys)(implicit clock: Clock = systemUTC): Provider = {
       val cookieDecoder = new IdentityCookieDecoder(identityKeys)
       val signer = new StringSigner(new DsaService(Some(identityKeys.publicDsaKey), None))
+
+      def displayNameFrom(request: RequestHeader, id: String): Option[String] = for {
+        guU <- request.cookies.get("GU_U")
+        guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
+        user = guUCookieData.user if user.id == id
+        displayName <- user.publicFields.displayName
+      } yield displayName
 
       def secureDataFrom(scGuU: Cookie): Option[SCUCookieData] = for {
         correctlySignedString <- Try(signer.getStringForSignedString(scGuU.value)).getOrElse { logger.warn(s"Bad sig on $scGuU"); None }
@@ -52,14 +70,11 @@ object AccessCredentials {
       } yield secureCookieData
 
       request => for {
-        scGuU <- request.cookies.get("SC_GU_U")
-        guU <- request.cookies.get("GU_U")
+        scGuU <- request.cookies.get(SC_GU_U)
         secureCookieData <- secureDataFrom(scGuU)
-        guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
-        user = guUCookieData.user if user.id == secureCookieData.id
       } yield AuthenticatedIdUser(
-        AccessCredentials.Cookies(scGuU.value, guU.value),
-        IdMinimalUser.from(user)
+        AccessCredentials.Cookies(scGuU.value),
+        IdMinimalUser(secureCookieData.id, displayNameFrom(request, secureCookieData.id))
       )
     }
 
@@ -75,7 +90,9 @@ object AccessCredentials {
   case class Token(tokenText: String) extends AccessCredentials
 
   object Token {
-    /** @param targetClientId Not confidential, eg "members-data-api" https://github.com/guardian/identity-token-auth-sample/blob/e640832d/main.scala#L28
+    val Header = "GU-IdentityToken"
+
+    /** @param targetClientId Not confidential, eg "membership" https://github.com/guardian/identity-token-auth-sample/blob/e640832d/main.scala#L28
       */
     def authProvider(identityKeys: IdentityKeys, targetClientId: String): Provider = {
       val collectionSigner = new CollectionSigner(new StringSigner(new DsaService(identityKeys.publicDsaKey, null)), LiftJsonConfig.formats)
@@ -94,7 +111,7 @@ object AccessCredentials {
       }
 
       request => for {
-        tokenText <- request.headers.get("GU-IdentityToken")
+        tokenText <- request.headers.get(Token.Header)
         user <- extractUserDataFromToken(tokenText).right.toOption
       } yield AuthenticatedIdUser(
         AccessCredentials.Token(tokenText),

--- a/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
@@ -58,7 +58,7 @@ object AccessCredentials {
       val signer = new StringSigner(new DsaService(Some(identityKeys.publicDsaKey), None))
 
       def displayNameFrom(request: RequestHeader, id: String): Option[String] = for {
-        guU <- request.cookies.get("GU_U")
+        guU <- request.cookies.get(GU_U)
         guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
         user = guUCookieData.user if user.id == id
         displayName <- user.publicFields.displayName

--- a/src/test/scala/com/gu/identity/play/AccessCredentialsSpec.scala
+++ b/src/test/scala/com/gu/identity/play/AccessCredentialsSpec.scala
@@ -4,69 +4,130 @@ import java.time.ZoneOffset.UTC
 import java.time.{Clock, Instant}
 
 import com.gu.identity.cookie.{ProductionKeys, SCUCookieData}
-import com.gu.identity.play.AccessCredentials.Cookies
-import com.gu.identity.play.AccessCredentials.Cookies.parseScGuU
+import com.gu.identity.play.AccessCredentials.Cookies.{GU_U, parseScGuU}
+import com.gu.identity.play.AccessCredentials.{Cookies, Token}
 import org.scalatestplus.play._
+import play.api.mvc.Cookie
 import play.api.test.FakeRequest
-
-import scala.util.Try
 
 class AccessCredentialsSpec extends PlaySpec {
 
+  case class ExampleUser(
+                          cookieCreds: Cookies,
+                          tokenCreds: Token,
+                          user: IdMinimalUser,
+                          guU: String
+  ) {
+    val scGuUCookie = cookieCreds.cookies
+    val guUCookie = Seq(Cookie(GU_U, guU))
+    val scGuUAndGuUCookies = cookieCreds.cookies ++ guUCookie
+  }
+
+  val Fred = ExampleUser(
+    AccessCredentials.Cookies(scGuU = "WyIxNTk4MDY5OCIsMTQ2NTMxMjU0Njk5M10.MCwCFADn0bo9Vn8UBzvqp-HS8Tqpg0ZOAhRUIGLF9CMQLclx3Ah5rVz_Ivzc9w"),
+    AccessCredentials.Token("eyJ1c2VyIjp7InByaW1hcnlFbWFpbEFkZHJlc3MiOm51bGwsImlkIjoiMTU5ODA2OTgiLCJwdWJsaWNGaWVsZHMiOnsiZGlzcGxheU5hbWUiOiJGcmVkQXV0aFRlc3QifSwicHJpdmF0ZUZpZWxkcyI6e30sInN0YXR1c0ZpZWxkcyI6eyJ1c2VyRW1haWxWYWxpZGF0ZWQiOmZhbHNlfSwiZGF0ZXMiOnsiYWNjb3VudENyZWF0ZWREYXRlIjoiMjAxNi0wMy0wOVQxNToxMjoyMVoifSwidXNlckdyb3VwcyI6W10sInNvY2lhbExpbmtzIjpbXSwiYWREYXRhIjp7fX0sImV4cGlyeVRpbWUiOiIyMDE4LTAzLTA5VDE2OjIzOjM3WiIsImlzc3VlZFRpbWUiOiIyMDE2LTAzLTA5VDE2OjIzOjM3WiIsInRhcmdldENsaWVudCI6Im1lbWJlcnNoaXAiLCJpc3N1ZWRDbGllbnQiOiJndS1hbmRyb2lkLW5ld3MifQ.MCwCFCmeJ4FFnCeEchhyOpgf4DVmu4D8AhRcSe2rq7CTeietBB8VXu03n5GRzw"),
+    IdMinimalUser(id = "15980698", displayName= Some("FredAuthTest")),
+    guU = "WyIxNTk4MDY5OCIsIiIsIkZyZWRBdXRoVGVzdCIsIjIiLDE0NjUzMTI1NDY5OTMsMSwxNDU3NTM2MzQxMDAwLGZhbHNlXQ.MC0CFBDmPMIyz4FZjc8DOTSujdDWrQ1uAhUAv32hMXHW-98dcZrHGkf0ZsF5UYU"
+)
+
+  val Bob = ExampleUser(
+    AccessCredentials.Cookies(scGuU = "WyIxNTk4MDczNyIsMTQ2NTMxMjk1ODEzNV0.MCwCFBXRJy3y6wG5C-L2nX13fbtw4_6lAhREra7GO2hdGC7NPaVeew9IRuU-gA"),
+    AccessCredentials.Token("eyJ1c2VyIjp7InByaW1hcnlFbWFpbEFkZHJlc3MiOm51bGwsImlkIjoiMTU5ODA3MzciLCJwdWJsaWNGaWVsZHMiOnsiZGlzcGxheU5hbWUiOiJCb2JBdXRoVGVzdCJ9LCJwcml2YXRlRmllbGRzIjp7fSwic3RhdHVzRmllbGRzIjp7InVzZXJFbWFpbFZhbGlkYXRlZCI6ZmFsc2V9LCJkYXRlcyI6eyJhY2NvdW50Q3JlYXRlZERhdGUiOiIyMDE2LTAzLTA5VDE1OjIyOjM3WiJ9LCJ1c2VyR3JvdXBzIjpbXSwic29jaWFsTGlua3MiOltdLCJhZERhdGEiOnt9fSwiZXhwaXJ5VGltZSI6IjIwMTgtMDMtMDlUMTY6MjU6MTVaIiwiaXNzdWVkVGltZSI6IjIwMTYtMDMtMDlUMTY6MjU6MTVaIiwidGFyZ2V0Q2xpZW50IjoibWVtYmVyc2hpcCIsImlzc3VlZENsaWVudCI6Imd1LWFuZHJvaWQtbmV3cyJ9.MC0CFQCpO3t-nAnUapUTzBaQdi2aZ9bCawIUYq7CanuVJjnDjKtIiL3zIsONk1k"),
+    IdMinimalUser(id = "15980737", displayName= Some("BobAuthTest")),
+    guU = "WyIxNTk4MDczNyIsIiIsIkJvYkF1dGhUZXN0IiwiMiIsMTQ2NTMxMjk1ODEzNSwxLDE0NTc1MzY5NTcwMDAsZmFsc2Vd.MCwCFENuiIJHWmN7x5dyZFMeGA2FvqADAhQJ8rrFP61ijW3UsRlbT6JjsL4ZPQ"
+  )
+
+
+  val BobCookiesExpirationInstant = Instant.parse("2016-06-07T15:22:38.135Z")
+
+  val timeBeforeExpiration = BobCookiesExpirationInstant.minusSeconds(600L)
+
+  def requestWith(cookies: Seq[Cookie]) = FakeRequest().withCookies(cookies :_*)
+
   "parsing Identity cookies" must {
-    def requestWith(accessCredentials: AccessCredentials.Cookies) = FakeRequest().withCookies(accessCredentials.cookies :_*)
 
     def authProviderWithClockSetTo(instant: Instant) =
       AccessCredentials.Cookies.authProvider(new ProductionKeys)(Clock.fixed(instant, UTC))
 
-    val validCookies = AccessCredentials.Cookies(
-      guU = "WyIxNTc0NzA5NCIsIiIsImlwYXRlc3QiLCIyIiwxNDU5ODU3MTA2MTc4LDAsMTQ1MjA4MTEwNTAwMCxmYWxzZV0.MCwCFEAUh7K0AuXPCZUjZX7I1KPApDazAhQ38PzDzsHaXQWTSpX51dylUhJcmw",
-      scGuU = "WyIxNTc0NzA5NCIsMTQ1OTg1NzEwNjE3OF0.MC0CFFrjLlGPWJjIFWZskQljWSToGLkSAhUAtaF7F2IAbh4YBeIENLQOlm4FUB8"
-    )
-
-    val cookiesExpirationInstant = Instant.parse("2016-04-05T11:51:46.178Z")
-
-    val instantBeforeExpiration = cookiesExpirationInstant.minusSeconds(1L)
-
     "extract an authenticated user from an HTTP request" in {
-      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+      val authProvider = authProviderWithClockSetTo(timeBeforeExpiration)
 
-      val authenticatedIdUserOpt = authProvider(requestWith(validCookies))
+      val authenticatedIdUser = authProvider(requestWith(Bob.scGuUCookie)).value
+
+      authenticatedIdUser.id mustBe Bob.user.id
+      authenticatedIdUser.credentials mustBe Bob.cookieCreds
+    }
+
+    "extract an authenticated user from an HTTP request, with the display name if the GU_U cookie is available" in {
+      val authProvider = authProviderWithClockSetTo(timeBeforeExpiration)
+
+      val authenticatedIdUserOpt = authProvider(requestWith(Bob.scGuUAndGuUCookies))
 
       val authenticatedIdUser = authenticatedIdUserOpt.value
-      authenticatedIdUser.user.id mustBe "15747094"
-      authenticatedIdUser.user.displayName mustBe Some("ipatest")
-      authenticatedIdUser.credentials mustBe validCookies
+
+      authenticatedIdUser.user.displayName mustBe Some("BobAuthTest")
+      authenticatedIdUser.user mustBe Bob.user
+      authenticatedIdUser.credentials mustBe Bob.cookieCreds
     }
 
     "report an HTTP request as unauthenticated when the current time is beyond the expiration date" in {
-      val authProvider = authProviderWithClockSetTo(cookiesExpirationInstant.plusSeconds(1L))
+      val authProvider = authProviderWithClockSetTo(BobCookiesExpirationInstant.plusSeconds(1L))
 
-      val authenticatedIdUserOpt = authProvider(requestWith(validCookies))
+      val authenticatedIdUserOpt = authProvider(requestWith(Bob.scGuUCookie))
 
       authenticatedIdUserOpt mustBe None
     }
 
     "report an HTTP request as unauthenticated when signature is bad" in {
-      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+      val authProvider = authProviderWithClockSetTo(timeBeforeExpiration)
 
-      val cookiesWithInvalidSignature = validCookies.copy(scGuU = validCookies.scGuU.dropRight(1))
+      val cookiesWithInvalidSignature = Bob.cookieCreds.copy(scGuU = Bob.cookieCreds.scGuU.dropRight(1))
 
-      val authenticatedIdUserOpt = authProvider(requestWith(cookiesWithInvalidSignature))
+      val authenticatedIdUserOpt = authProvider(requestWith(cookiesWithInvalidSignature.cookies))
 
       authenticatedIdUserOpt mustBe None
     }
 
     "report an HTTP request as unauthenticated when cookie is validly signed but has invalid content (from somewhere else!)" in {
-      val authProvider = authProviderWithClockSetTo(instantBeforeExpiration)
+      val authProvider = authProviderWithClockSetTo(timeBeforeExpiration)
 
-      val authenticatedIdUserOpt = authProvider(requestWith(validCookies.copy(scGuU = validCookies.guU)))
+      val authenticatedIdUserOpt = authProvider(requestWith(Bob.guUCookie))
 
       authenticatedIdUserOpt mustBe None
     }
 
     "parse Identity details out of SC_GU_U cookie json" in {
       parseScGuU("""["15747094",1459857106178]""") mustBe Some(SCUCookieData("15747094",1459857106178L))
+    }
+  }
+
+  "parsing requests that accept multiple authentication methods" must {
+
+    val authProvider =
+      AuthenticatedIdUser.provider(Cookies.authProvider(new ProductionKeys)(Clock.fixed(timeBeforeExpiration, UTC)), Token.authProvider(new ProductionKeys, "membership"))
+
+    "authenticate the request if it has only a valid token" in {
+      authProvider(FakeRequest().withHeaders(Token.Header -> Bob.tokenCreds.tokenText)).value.user.id mustBe Bob.user.id
+      authProvider(FakeRequest().withHeaders(Token.Header -> Fred.tokenCreds.tokenText)).value.user.id mustBe Fred.user.id
+    }
+
+    "authenticate the request if it has only a valid cookie" in {
+      authProvider(requestWith(Bob.scGuUCookie)).value.user.id mustBe Bob.user.id
+      authProvider(requestWith(Fred.scGuUCookie)).value.user.id mustBe Fred.user.id
+    }
+
+    "authenticate the request if it contains identical users, returning the credentials from the first match" in {
+      val authenticatedIdUser = authProvider(requestWith(Bob.scGuUCookie).withHeaders(Token.Header -> Bob.tokenCreds.tokenText)).value
+      authenticatedIdUser.credentials mustBe Bob.cookieCreds
+      authenticatedIdUser.user.id mustBe Bob.user.id
+    }
+
+    "extract the display name from token if it's provided" in {
+      authProvider(requestWith(Bob.scGuUCookie).withHeaders(Token.Header -> Bob.tokenCreds.tokenText)).value.user.displayName mustBe Bob.user.displayName
+    }
+
+    "not authenticate the request if it contains differing users" in {
+      authProvider(requestWith(Bob.scGuUCookie).withHeaders(Token.Header -> Fred.tokenCreds.tokenText)) mustBe None
     }
   }
 }


### PR DESCRIPTION
Clients (ie Mobile apps) can now authenticate with SC_GU_U alone. In order for test-users to work, you need to send the displayName as well, and this can come from either the GU_U cookie or a token. The mobile apps will probably end up sending both SC_GU_U and the access-token, in order to allow use of Test Users (which require the displayName to determine if the user is a test user).

This change drops the requirement for the (deprecated) GU_U cookie to authenticate with cookies - though if the cookie _is_ present, the displayName will be read from it, as this is still very important for Membership/Subs test users.

The API has not changed at all (apart from removing GU_U from the `Cookies` case class), so this should be an easy upgrade.

cc @DiegoVazquezNanini 
