### PR TITLE
Bump Play version to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # identity-play-auth
 A small library for Guardian Identity authentication with the Play framework
 
+* Use 2.x series for Play 2.6
 * Use 1.x series for Play 2.5
 * Use 0.x series for Play 2.4

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val play = "com.typesafe.play" %% "play" % "2.5.12"
+  val play = "com.typesafe.play" %% "play" % "2.6.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.79"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.6"
   val scalaTestPlus = "org.scalatestplus" %% "play" % "1.4.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4-SNAPSHOT"
+version in ThisBuild := "2.0-SNAPSHOT"


### PR DESCRIPTION
The Play2.5 release of this library is not compatible with apps running Play 2.6, so we need a new version series to allow projects to upgrade to Play 2.6.