### PR TITLE
Proposed changes to identity-play-auth

### DIFF
--- a/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticatedIdUser.scala
@@ -17,18 +17,25 @@ import play.api.mvc.{Cookie, RequestHeader}
 import scala.language.implicitConversions
 import scala.util.Try
 
+// TODO: remove IdMinimalUser case class in favour of 'flat' - fields id: String, displayName: Option[String]
 case class AuthenticatedIdUser(credentials: AccessCredentials, user: IdMinimalUser) {
 
+  // TODO: remove; no need for this functionality
   def setDisplayName(displayNameOpt: Option[String]):AuthenticatedIdUser =
     copy(user = user.copy(displayName = displayNameOpt))
 
 }
 
 object AuthenticatedIdUser {
+
+  // TODO: remove implicit conversion; adds complexity and is not necessary
   implicit def authenticatedIdUserToMinimalUser(aid: AuthenticatedIdUser): IdMinimalUser = aid.user
 
+  // TODO: remove this type alias in favour of UserAuthenticator class with method:
+  // authenticateUser(requestHeader: RequestHeader): Future[Option[AuthenticatedIdUser]]
   type Provider = RequestHeader => Option[AuthenticatedIdUser]
 
+  // TODO: remove this; not necessary
   def provider(providers: Provider*) = {
     r : RequestHeader =>
       val users = providers.flatMap(_ (r)) // may be differing users!
@@ -38,6 +45,7 @@ object AuthenticatedIdUser {
       } yield principal.setDisplayName(users.flatMap(_.displayName).headOption)
   }
 
+  // TODO: remove this; add withDisplayNameProvider() as method on UserAuthenticator (if it's actually required)
   implicit class RichProvider(provider: Provider) {
     /**
       * @return the authenticated user, with the display name from the additionalDisplayNameProvider, so long
@@ -70,6 +78,8 @@ object AccessCredentials {
 
     val logger = Logger(getClass)
 
+    // TODO: implement this in UserAuthenticator class
+    // implementation should make a call to the identity API
     def authProvider(identityKeys: IdentityKeys)(implicit clock: Clock = systemUTC): Provider = {
       val cookieDecoder = new IdentityCookieDecoder(identityKeys)
       val signer = new StringSigner(new DsaService(Some(identityKeys.publicDsaKey), None))
@@ -112,6 +122,8 @@ object AccessCredentials {
 
     /** @param targetClientId Not confidential, eg "membership" https://github.com/guardian/identity-token-auth-sample/blob/e640832d/main.scala#L28
       */
+    // TODO: implement this in UserAuthenticator class
+    // implementation should make a call to the identity API
     def authProvider(identityKeys: IdentityKeys, targetClientId: String): Provider = {
       val collectionSigner = new CollectionSigner(new StringSigner(new DsaService(identityKeys.publicDsaKey, null)), LiftJsonConfig.formats)
 

--- a/src/main/scala/com/gu/identity/play/AuthenticationService.scala
+++ b/src/main/scala/com/gu/identity/play/AuthenticationService.scala
@@ -3,6 +3,7 @@ package com.gu.identity.play
 import com.gu.identity.cookie.IdentityKeys
 import play.api.mvc.{Request, RequestHeader}
 
+// TODO: remove - not adding any useful functionality
 trait AuthenticationService {
 
   val identityKeys: IdentityKeys

--- a/src/main/scala/com/gu/identity/play/CookieBuilder.scala
+++ b/src/main/scala/com/gu/identity/play/CookieBuilder.scala
@@ -7,6 +7,8 @@ import com.gu.identity.play.idapi.CookieDescriptionJson._
 import play.api.libs.json._
 import play.api.mvc.Cookie
 
+// TODO: are these utility methods really needed in this library? Consider removing.
+
 object CookieBuilder {
 
   def cookiesFromDescription(

--- a/src/main/scala/com/gu/identity/play/IdMinimalUser.scala
+++ b/src/main/scala/com/gu/identity/play/IdMinimalUser.scala
@@ -2,6 +2,8 @@ package com.gu.identity.play
 
 import com.gu.identity.model.{User => LegacyMutableUser}
 
+// TODO: c.f. comment on AuthenticatedIdUser class; remove IdMinimalUser
+
 case class IdMinimalUser(id: String, displayName: Option[String])
 
 object IdMinimalUser {

--- a/src/main/scala/com/gu/identity/play/IdUser.scala
+++ b/src/main/scala/com/gu/identity/play/IdUser.scala
@@ -2,6 +2,8 @@ package com.gu.identity.play
 
 import play.api.libs.json.Json
 
+// TODO: check model of StatusFields in identity-model can be used instead
+// this model has different fields to fields in identity-model analog
 case class StatusFields(receiveGnmMarketing: Option[Boolean] = None,
                         receive3rdPartyMarketing: Option[Boolean] = None)
 
@@ -10,6 +12,8 @@ object StatusFields {
   implicit val readsStatusFields = Json.reads[StatusFields]
 }
 
+// TODO: check model of StatusFields in identity-model can be used instead
+// this model contains subset of fields in identity-model analog
 case class PublicFields(displayName: Option[String])
 
 object PublicFields {
@@ -17,6 +21,8 @@ object PublicFields {
   implicit val readsPublicFields = Json.reads[PublicFields]
 }
 
+// TODO: check model of TelephoneNumber in identity-model can be used instead
+// definition identical
 case class TelephoneNumber(countryCode: Option[String], localNumber: Option[String])
 
 object TelephoneNumber {
@@ -24,6 +30,8 @@ object TelephoneNumber {
   implicit val readsTelephoneNumber = Json.reads[TelephoneNumber]
 }
 
+// TODO: check model of PrivateFields in identity-model can be used instead
+// this model contains subset of fields in identity-model analog
 //this can't be a Map[String,String] as PrivateFields in Identity has other object types
 case class PrivateFields(firstName: Option[String] = None,
                          secondName: Option[String] = None,
@@ -50,7 +58,10 @@ object PrivateFields {
 }
 
 
-
+// TODO: check model of User in identity-model can be used instead
+// privateFields in identity-model analog modeled as required
+// statusFields in identity-model analog modeled as required
+// minimal not defined in identity-model analog
 case class IdUser(id: String,
   primaryEmailAddress: String,
   publicFields: PublicFields,

--- a/src/main/scala/com/gu/identity/play/ProxiedIP.scala
+++ b/src/main/scala/com/gu/identity/play/ProxiedIP.scala
@@ -8,6 +8,8 @@ import play.api.mvc.RequestHeader
 
 import scala.util.Try
 
+// TODO: are these utility methods really needed in this library? Consider removing.
+
 object ProxiedIP {
   def getIP(request: RequestHeader): Option[InetAddress] = for {
     xFor <- request.headers.get(X_FORWARDED_FOR)

--- a/src/main/scala/com/gu/identity/play/idapi/CreateIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/idapi/CreateIdUser.scala
@@ -3,6 +3,9 @@ package com.gu.identity.play.idapi
 import com.gu.identity.play.{PrivateFields, PublicFields, StatusFields}
 import play.api.libs.json.Json
 
+// TODO: remove this file;
+// not responsibility of identity-play-auth to provide case classes that model identity API requests / responses
+
 case class CreateIdUser(
   primaryEmailAddress: String,
   password: String,

--- a/src/main/scala/com/gu/identity/play/idapi/UpdateIdUser.scala
+++ b/src/main/scala/com/gu/identity/play/idapi/UpdateIdUser.scala
@@ -3,6 +3,8 @@ package com.gu.identity.play.idapi
 import com.gu.identity.play.{PrivateFields, PublicFields, StatusFields}
 import play.api.libs.json.Json
 
+// TODO: remove this file;
+// not responsibility of identity-play-auth to provide case classes that model identity API requests / responses
 
 case class UpdateIdUser(
   primaryEmailAddress: Option[String] = None,

--- a/src/main/scala/com/gu/identity/play/idapi/UserRegistrationResult.scala
+++ b/src/main/scala/com/gu/identity/play/idapi/UserRegistrationResult.scala
@@ -4,6 +4,9 @@ import com.gu.identity.model.cookies.{CookieDescription, CookieDescriptionList}
 import com.gu.identity.play.IdUser
 import play.api.libs.json.Json
 
+// TODO: remove this file;
+// not responsibility of identity-play-auth to provide case classes that model identity API requests / responses
+
 object CookieDescriptionJson {
 
   implicit val readsCookieDescriptionList = Json.reads[CookieDescription]


### PR DESCRIPTION
Identity are wanting to centralise user authentication i.e. an application should authenticate a user by making a call to the authentication endpoint in identity API.

To achieve this for Guardian applications using this library (members-data-api, membership-frontend, support-frontend, subscriptions-frontend), update the implementation of the authentication methods in identity-play-auth to call identity API and then import this updated version.

Note that because this update will make breaking changes:
```scala
RequestHeader => Future[Option[U]]
```
instead of:
```scala
RequestHeader => Option[U]
```
this might be a good time to ship other breaking changes as well i.e. removing methods and data models that arguably don't belong in this library.

This PR details the proposed changes. Approving this PR = approving the plan laid out in the in-line comments.

