### PR TITLE
bump identity cookie

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   val play = "com.typesafe.play" %% "play" % "2.6.7"
-  val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.162"
+  val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.184-M6"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.6"
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2"
   val scalactic = "org.scalactic" %% "scalactic" % "3.0.4"


### PR DESCRIPTION
A project with:

```
"com.gu.identity" %% "identity-play-auth" % "2.5"
"com.gu.identity" %% "identity-model-play" % "3.184-M6"
```

can lead to some fatal runtime exceptions: identity-play-auth depends on identity-cookie which initialises `UserDates`'s instances but the method `UserDates.apply` is not compatible between the versions of identity-model used by `"identity-play-auth" % "2.5"` and `"identity-model-play" % "3.184-M6"` respectively.

This change is in the context of deprecating this library and is a transitory solution. The intention is still for this library not to be used.